### PR TITLE
Fix amc2moodle resolution

### DIFF
--- a/amc2moodle/amc2moodle/README.md
+++ b/amc2moodle/amc2moodle/README.md
@@ -120,6 +120,10 @@ Options can be passed to `amc2moodle` using the `amc2moodle` internal command `\
 Such line are ignored in standard LaTeX processing and uncommented for `amc2moodle` workflow.
 Another possibility is to use "magic comments" to add some specific TeX code/text to moodle question (link to external file or video url, change in scoring, remove or add answers).
 
+Currently, accessible **general options** are :
+  - `imgResolution`, to change de quality of images. It applyes only for images that are converted into png.
+other specific options are given in each question type sections.
+
 ### Numerical questions
 These questions defined in AMC with `\AMCNumericChoices` are converted into `numerical` questions in moodle. The target value and its tolerance are preserved. However, exponential notation, bases are not yet supported. Moodle also supports a units in numerical questions, but it is not used here. 
 For question with floating point operations, **you need to comment `\usepackage{fp}` during the conversion** (required internally by AMC). If you need to realize computation in the question, prefer `\pgfmathparse` that is handled by LaTeXML.

--- a/amc2moodle/amc2moodle/convert.py
+++ b/amc2moodle/amc2moodle/convert.py
@@ -901,7 +901,12 @@ class AMCQuiz:
                  'ltx_centering': 'center'}
 
         for Ii in Ilist:
-            img_name = Ii.attrib['candidates'].split(',')[-1]   #get the last candidates
+            try:
+                img_name = Ii.attrib['candidates'].split(',')[-1]   # get the last candidates
+            except KeyError as e:
+                print('WARNING : No Image file candidates. ',
+                      'Probably due to a wrong path : {}'.format(Ii.attrib['graphic']))
+                raise e
             ext = img_name.split('.')[-1]
             # not all attrib are mandatory... check if they exist before using them
             # try for class

--- a/amc2moodle/amc2moodle/test/common-bank.tex
+++ b/amc2moodle/amc2moodle/test/common-bank.tex
@@ -3,7 +3,8 @@
 \element{cat1}{
   \begin{question}{Qsimple:img}
     On souhaite faire passer \textit{exactement}, par $N$ points donnés, un \texttt{polynôme} de degré \textbf{strictement} égal à $N-1$. Pour trouver les coefficients on doit résoudre un \emph{problème}
-
+% Use "magic comments" to set imgResolution amc2moodle.
+%amc2moodle \SetOption{imgResolution}{72}  
     \begin{center}
       \includegraphics[width=0.5\textwidth]{./Figures/other/schema_interpL.png}
     \end{center}
@@ -15,7 +16,7 @@
         \begin{flushright}
           \includegraphics[height=2cm]{./Figures/tinymonk.pdf}
         \end{flushright}
-        \begin{flushleft}
+        \begin{flushleft}   
           \includegraphics[height=3cm]{./Figures/tinymonk.pdf}
         \end{flushleft}
       }


### PR DESCRIPTION
Few fixes in amc2moodle conversion :
  - Add an option to change resolution used in images conversion and map it to a _magic_ command :
`%amc2moodle \SetOption{imgResolution}{72}  `. Increase the default value to 100 (72 is the default in wand). Related to issue #39.
  - Add explicit warning message about path if there is no image candidates (issue #37). The missing `candidates` now raises an error and stops the conversion.
