### PR TITLE
Fix CI crashes due to dependancies evolution.

### DIFF
--- a/.github/workflows/ci-mac-os.yml
+++ b/.github/workflows/ci-mac-os.yml
@@ -43,10 +43,10 @@ jobs:
         brew install imagemagick
 
         # install brew latex packages, libs and lateXML
-        brew cask install basictex        
+        brew install --cask basictex
 
         brew install latexml
-        
+
     - name: Update $PATH
       # run: echo ::add-path::/Library/TeX/texbin # depreciated
       run: echo "/Library/TeX/texbin" >> $GITHUB_PATH

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -35,7 +35,9 @@ jobs:
         
         # install ubuntu package
         sudo apt-get update
-        sudo apt-get install imagemagick
+        # need to add ghostscript explicitly (only 'recommanded' by imagemagick package)
+        # but 'libmagickwand-dev' is installed
+        sudo apt-get install ghostscript imagemagick
         # move policy file
         sudo mv /etc/ImageMagick-6/policy.xml /etc/ImageMagick-6/policy.xml.off
         # texlive-fonts-recommended (bophook in texlive-latex-extra) required by moodle2amc test


### PR DESCRIPTION
Both CI script stop to work. To fix it :
  - ubuntu : Now, need to explicitly install ghostscript for pdf conversion
  - macos : `cask` syntax change