### PR TITLE
Improve verbosity management

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Then the output LaTeX can be edited and included for creating amc exams. Example
 
 
 ## Troubleshooting
-In case of problem, do not hesitate to ask help on [issues](https://github.com/nennigb/amc2moodle/issues)
+In case of problem, do not hesitate to ask help on [issues](https://github.com/nennigb/amc2moodle/issues). Both binaries (`amc2moodle` and `moodle2amc`) write full log in log files based on the name of the input file (`_amc2moodle.log` and `_amc2moodle.log` suffixes are added on these files).
   - 'convert: not authorized..' see ImageMagick policy.xml file see [here](https://stackoverflow.com/questions/52699608/wand-policy-error-error-constitute-c-readimage-412)
   - bugs with tikz-LaTeXML in texlive 2019/2020: please update the following `perl` modules `Parse::RecDescent`, `XML::LibXML` and `XML::LibXSLT` [here](https://github.com/brucemiller/LaTeXML/issues/1279) with `cpan` or `cpanm`in CLI.
 

--- a/amc2moodle/amc2moodle/README.md
+++ b/amc2moodle/amc2moodle/README.md
@@ -140,7 +140,7 @@ Currently, the main **general options** accessible by `\SetQuizOption` (or `\Set
   - `answer_numbering_format` ('123', 'abc', 'iii', 'none', 'ABCD'), only at quiz level, to specify the numbering format in moodle.
   - other general options can be found in the `convert.py` header.
 Specific options are given in each question type section.
-
+@
 ### Numerical questions
 These questions defined in AMC with `\AMCNumericChoices` are converted into `numerical` questions in moodle. The target value and its tolerance are preserved. However, exponential notation, bases are not yet supported. Moodle also supports a units in numerical questions, but it is not used here. 
 For question with floating point operations, **you need to comment `\usepackage{fp}` during the conversion** (required internally by AMC). If you need to realize computation in the question, prefer `\pgfmathparse` that is handled by LaTeXML.

--- a/amc2moodle/amc2moodle/amc2moodle_class.py
+++ b/amc2moodle/amc2moodle/amc2moodle_class.py
@@ -75,7 +75,7 @@ def writePipeOnOutput(process,streamIn,output:Callable):
     during process executed by subprocess.Popen
     """
     while process.poll() is None:
-        output(streamIn.readline())
+        output(streamIn.readline().strip())
     # write the rest from the buffer
     output(streamIn.read())
 
@@ -230,7 +230,8 @@ class amc2moodle:
         """
         # run LaTeXML on magictex file
         Logger.info(' > Running LaTeXML conversion')
-        latexmlProcess = subprocess.Popen([
+        LoggerXML = logging.getLogger(' LaTexML ')
+        with subprocess.Popen([
             'latexml',
             '--noparse',
             '--nocomments',
@@ -239,21 +240,26 @@ class amc2moodle:
             self.magictex],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            text=True)
-        # write stdout and stderr in parallel to the right logging outputs
-        # caution LaTeXML uses only STDERR... (version 0.8.5)
-        # all outputs will be written in debug log
-        with ThreadPoolExecutor(2) as pool:
-            rstdout = pool.submit(writePipeOnOutput,
-                    latexmlProcess,
-                    latexmlProcess.stdout,
-                    Logger.debug)
-            rstderr = pool.submit(writePipeOnOutput,
-                    latexmlProcess,
-                    latexmlProcess.stderr,
-                    Logger.debug)
-            rstdout.result()
-            rstderr.result()
+            text=True) as latexmlProcess:
+            #while latexmlProcess.poll() is None:
+            #    Logger.debug(latexmlProcess.stdout.read())
+            #writePipeOnOutput(latexmlProcess,latexmlProcess.stderr,Logger.debug)
+
+            # write stdout and stderr in parallel to the right logging outputs
+            # caution LaTeXML uses only STDERR... (version 0.8.5)
+            # all outputs will be written in debug log
+            with ThreadPoolExecutor(2) as pool:
+                rstdout = pool.submit(writePipeOnOutput,
+                        latexmlProcess,
+                        latexmlProcess.stdout,
+                        LoggerXML.info)
+                rstderr = pool.submit(writePipeOnOutput,
+                        latexmlProcess,
+                        latexmlProcess.stderr,
+                        LoggerXML.debug)
+                rstdout.result()
+                rstderr.result()
+        #latexmlProcess.wait()
         return latexmlProcess.returncode == 0
 
     def runXMLindent(self):
@@ -289,7 +295,8 @@ class amc2moodle:
 
         Logger.info(' > Running LaTeXML pre-processing...')
         # process magictex as tex input
-        if self.runLaTeXML():
+        statusLaTeXML = self.runLaTeXML()
+        if statusLaTeXML:
             # run script
             Logger.info(' > Running Python conversion...')
             convert.to_moodle(

--- a/amc2moodle/amc2moodle/amc2moodle_class.py
+++ b/amc2moodle/amc2moodle/amc2moodle_class.py
@@ -204,7 +204,7 @@ class amc2moodle:
               like 1/2, 1/3 etc...
         """
         for item in msg.split('\n'):
-            Logger.warning(item)
+            Logger.info(item)
 
     def removeMagicComment(self):
         """ Remove magic comments prefix to enable amc2moodle dedicated LaTeX
@@ -236,7 +236,8 @@ class amc2moodle:
         """
         # run LaTeXML on magictex file
         Logger.info(' > Running LaTeXML conversion')
-        LoggerXML = logging.getLogger(' LaTexML ')
+        # LoggerXML = logging.getLogger('LaTexML')
+        #TODO: caution with 'universal_newlines=' (new syntax from Python 3.7: text=)
         with subprocess.Popen([
             'latexml',
             '--noparse',
@@ -258,11 +259,11 @@ class amc2moodle:
                 rstdout = pool.submit(writePipeOnOutput,
                         latexmlProcess,
                         latexmlProcess.stdout,
-                        LoggerXML.info)
+                        Logger.debug)
                 rstderr = pool.submit(writePipeOnOutput,
                         latexmlProcess,
                         latexmlProcess.stderr,
-                        LoggerXML.debug)
+                        Logger.debug)
                 rstdout.result()
                 rstderr.result()
         #latexmlProcess.wait()

--- a/amc2moodle/amc2moodle/amc2moodle_class.py
+++ b/amc2moodle/amc2moodle/amc2moodle_class.py
@@ -75,9 +75,13 @@ def writePipeOnOutput(process,streamIn,output:Callable):
     during process executed by subprocess.Popen
     """
     while process.poll() is None:
-        output(streamIn.readline().strip())
+        msg = streamIn.readline().strip()
+        if msg !="":
+            output(msg)
     # write the rest from the buffer
-    output(streamIn.read())
+    msg = streamIn.read().strip()
+    if msg !="":
+        output(msg)
 
 
 class amc2moodle:
@@ -189,7 +193,7 @@ class amc2moodle:
     def endMessage(self):
         """ Show end message explaining moodle inmport procedure.
         """
-        Logger.warning("""File converted. Check below for errors...
+        msg="""  File converted. Check below for errors...
 
             For import into moodle :
             --------------------------------
@@ -198,7 +202,9 @@ class amc2moodle:
             - In the option chose : 'choose the closest grade if not listed'
               in the 'General option' since Moodle used tabulated grades
               like 1/2, 1/3 etc...
-        """)
+        """
+        for item in msg.split('\n'):
+            logging.warning(item)
 
     def removeMagicComment(self):
         """ Remove magic comments prefix to enable amc2moodle dedicated LaTeX

--- a/amc2moodle/amc2moodle/amc2moodle_class.py
+++ b/amc2moodle/amc2moodle/amc2moodle_class.py
@@ -204,7 +204,7 @@ class amc2moodle:
               like 1/2, 1/3 etc...
         """
         for item in msg.split('\n'):
-            logging.warning(item)
+            Logger.warning(item)
 
     def removeMagicComment(self):
         """ Remove magic comments prefix to enable amc2moodle dedicated LaTeX

--- a/amc2moodle/amc2moodle/amc2moodle_class.py
+++ b/amc2moodle/amc2moodle/amc2moodle_class.py
@@ -246,7 +246,7 @@ class amc2moodle:
             self.magictex],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            text=True) as latexmlProcess:
+            universal_newlines=True) as latexmlProcess:
             #while latexmlProcess.poll() is None:
             #    Logger.debug(latexmlProcess.stdout.read())
             #writePipeOnOutput(latexmlProcess,latexmlProcess.stderr,Logger.debug)

--- a/amc2moodle/amc2moodle/amc2moodle_class.py
+++ b/amc2moodle/amc2moodle/amc2moodle_class.py
@@ -18,6 +18,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
+from typing import Callable
 from ..amc2moodle import convert
 from ..utils.flatex import Flatex
 import subprocess
@@ -26,7 +27,11 @@ import os
 from importlib import util  # python 3.x
 import tempfile
 from distutils.dir_util import copy_tree
+import logging
+from concurrent.futures import ThreadPoolExecutor
 
+# activate logger
+Logger = logging.getLogger(__name__)
 
 def checkTools(show=True):
     """ Check if the required Tools are available.
@@ -35,18 +40,18 @@ def checkTools(show=True):
     wand_loader = util.find_spec('wand') 
     wandOk = wand_loader is not None
     if not wandOk:
-        print ("Please install Wand's Python module")
+        Logger.critical("Please install Wand's Python module")
     # lxml Python Module
     lxml_loader = util.find_spec('lxml') 
     lxmlOk = lxml_loader is not None
     if not lxmlOk:
-        print ("Please install lxml's Python module")
+        Logger.critical("Please install lxml's Python module")
     # LaTeXML
     latexMLwhich = subprocess.run(['which', 'latexml'],
                                   stdout=subprocess.DEVNULL)
     latexmlOk = latexMLwhich.returncode == 0
     if not latexmlOk:
-        print ("Please install LaTeXML software (see https://dlmf.nist.gov/LaTeXML/)")
+        Logger.critical("Please install LaTeXML software (see https://dlmf.nist.gov/LaTeXML/)")
 
     return wandOk and lxmlOk and latexmlOk
 
@@ -64,6 +69,15 @@ def getPathFile(fileIn):
     if not dirname:
         dirname = '.'
     return dirname
+
+def writePipeOnOutput(process,streamIn,output:Callable):
+    """ Write the stream from a pipe through an output
+    during process executed by subprocess.Popen
+    """
+    while process.poll() is None:
+        output(streamIn.readline())
+    # write the rest from the buffer
+    output(streamIn.read())
 
 
 class amc2moodle:
@@ -101,11 +115,11 @@ class amc2moodle:
         None.
 
         """
-        print('========================')
-        print('========================')
-        print('=== Start amc2moodle ===')
-        print('========================')
-        print('========================')
+        Logger.info('========================')
+        Logger.info('========================')
+        Logger.info('=== Start amc2moodle ===')
+        Logger.info('========================')
+        Logger.info('========================')
         # Set temp XML filename for internal use
         self.tempxmlfiledef = 'tex2xml.xml'
         self.tempxmlfile = 'tex2xml.xml'
@@ -151,7 +165,7 @@ class amc2moodle:
     def cleanUpTemp(self):
         """ Clean-up temp directory created by tempfile.TemporaryDirectory().
         """
-        print(' > Clean-up tempfile.')
+        Logger.debug(' > Clean-up tempfile.')
         self.tempdir.cleanup()
         # remove magictex temp file
         if not self.keepFlag:
@@ -161,21 +175,21 @@ class amc2moodle:
         """ Show loaded parameters.
         """
         disable = {True:'enable', False:'disable'}
-        print('====== Parameters ======')
-        print(' > path input TeX: %s' % getPathFile(self.inputtex))
-        print(' > input TeX file: %s' % getFilename(self.inputtex))
-        print(' > temporary directory: %s' % getPathFile(self.tempdir.name))
-        print(' > path output TeX: %s' % getPathFile(self.output))
-        print(' > output XML file: %s' % getFilename(self.output))
-        print(' > temp XML file: %s' % self.tempxmlfile)
-        print(' > keep temp files: %s' % self.keepFlag)
-        print(' > categorie name: %s' % self.catname)
-        print(' > magic comments: %s' % disable[self.magic_flag])
+        Logger.debug('====== Parameters ======')
+        Logger.debug(' > path input TeX: %s' % getPathFile(self.inputtex))
+        Logger.debug(' > input TeX file: %s' % getFilename(self.inputtex))
+        Logger.debug(' > temporary directory: %s' % getPathFile(self.tempdir.name))
+        Logger.debug(' > path output TeX: %s' % getPathFile(self.output))
+        Logger.debug(' > output XML file: %s' % getFilename(self.output))
+        Logger.debug(' > temp XML file: %s' % self.tempxmlfile)
+        Logger.debug(' > keep temp files: %s' % self.keepFlag)
+        Logger.debug(' > categorie name: %s' % self.catname)
+        Logger.debug(' > magic comments: %s' % disable[self.magic_flag])
 
     def endMessage(self):
         """ Show end message explaining moodle inmport procedure.
         """
-        print("""File converted. Check below for errors...
+        Logger.warning("""File converted. Check below for errors...
 
             For import into moodle :
             --------------------------------
@@ -215,15 +229,32 @@ class amc2moodle:
         """ Run LaTeXML on the input TeX file.
         """
         # run LaTeXML on magictex file
-        print(' > Running LaTeXML conversion')
-        runStatus = subprocess.run([
+        Logger.info(' > Running LaTeXML conversion')
+        latexmlProcess = subprocess.Popen([
             'latexml',
             '--noparse',
             '--nocomments',
             '--path=%s' % os.path.dirname(__file__),
             '--dest=%s' % self.tempxmlfile,
-            self.magictex])
-        return runStatus.returncode == 0
+            self.magictex],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True)
+        # write stdout and stderr in parallel to the right logging outputs
+        # caution LaTeXML uses only STDERR... (version 0.8.5)
+        # all outputs will be written in debug log
+        with ThreadPoolExecutor(2) as pool:
+            rstdout = pool.submit(writePipeOnOutput,
+                    latexmlProcess,
+                    latexmlProcess.stdout,
+                    Logger.debug)
+            rstderr = pool.submit(writePipeOnOutput,
+                    latexmlProcess,
+                    latexmlProcess.stderr,
+                    Logger.debug)
+            rstdout.result()
+            rstderr.result()
+        return latexmlProcess.returncode == 0
 
     def runXMLindent(self):
         """ Run XML indentation with subprocess.
@@ -237,30 +268,30 @@ class amc2moodle:
 
         # linux
         if xmlindentOk:
-            print(' > Indenting XML output...')
+            Logger.debug(' > Indenting XML output...')
             subprocess.run(['xmlindent', self.output, '-o', self.output],
                            stdout=subprocess.DEVNULL)
         # MacOS
         if xmllintOk and not xmlindentOk:
-            print(' > Indenting XML output...')
+            Logger.debug(' > Indenting XML output...')
             subprocess.run(['xmllint', self.output,'--format','--output', self.output],
                            stdout=subprocess.DEVNULL)
 
     def runBuilding(self):
         """ Build the xml file for Moodle quizz.
         """
-        print('====== Build XML =======')
+        Logger.info('====== Build XML =======')
         # remove magic comment, return magictex
         if self.magic_flag:
-            print(' > Search for magic comments...')
+            Logger.info(' > Search for magic comments...')
         self.removeMagicComment()
 
 
-        print(' > Running LaTeXML pre-processing...')
+        Logger.info(' > Running LaTeXML pre-processing...')
         # process magictex as tex input
         if self.runLaTeXML():
             # run script
-            print(' > Running Python conversion...')
+            Logger.info(' > Running Python conversion...')
             convert.to_moodle(
                 filein=getFilename(self.tempxmlfile),
                 pathin=getPathFile(self.inputtex),
@@ -275,7 +306,7 @@ class amc2moodle:
                 tempdirSave = tempfile.mkdtemp(prefix='tmp_amc2moodle_',
                                                dir=getPathFile(self.output))
                 #
-                print(' > Save all temp files in: %s' % tempdirSave)
+                Logger.info(' > Save all temp files in: %s' % tempdirSave)
                 copy_tree(self.tempdir.name, tempdirSave)
 
             # run XMLindent
@@ -289,5 +320,5 @@ class amc2moodle:
             self.endMessage()
 
         else:
-            print('ERROR during LaTeXML processing.')
+            Logger.error('ERROR during LaTeXML processing.')
             sys.exit(1)

--- a/amc2moodle/amc2moodle/bin/amc2moodle
+++ b/amc2moodle/amc2moodle/bin/amc2moodle
@@ -18,12 +18,12 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
+from amc2moodle.utils.customLogging import customLogger
 import amc2moodle as amdlpkg
 from amc2moodle.amc2moodle import amc2moodle_class as a2m
 import argparse
 import os
 import sys
-import logging
 
 
 def run():
@@ -68,7 +68,7 @@ def run():
                         version="%(prog)s v{version}".format(version=amdlpkg.__version__))
     parser.add_argument("-v", "--verbose",
                         help='''Show all log messages in CLI''',
-                        required=False, action="store_true")
+                        required=False, action="count")
     parser.add_argument("-s", "--silent",
                         help='''Hide all messages in CLI (log file is still written) (override verbosity)''',
                         required=False, action="store_true")
@@ -93,33 +93,15 @@ def run():
     silentMode = args.silent
     verboseMode = args.verbose
 
-    # DEFAULT
-    DEFAULT_LOG_FORMATTER = '%(asctime)s [%(levelname)s]: %(message)s '
-    DEFAULT_LOG_DEBUG_FORMATTER = '%(asctime)s-({}-%(name)s) [%(levelname)s]: %(message)s '.format(amdlpkg.__version__)
-    DEFAULT_FMT_TIME = '%H:%M:%S'
-    # create global logger
-    # logging.basicConfig(level=logging.DEBUG)
-    # load root logger
-    rootLogger = logging.getLogger('amc2moodle')
-    rootLogger.setLevel(logging.DEBUG)
-    # create basic stream logger
-    sH = logging.StreamHandler(stream=sys.stdout)
-    sH.setFormatter(logging.Formatter(fmt=DEFAULT_LOG_FORMATTER,datefmt=DEFAULT_FMT_TIME))
-    sH.setLevel(logging.INFO)    
+    #adapt verbosemode
+    if not verboseMode:
+        verboseMode = 0
 
-    # activate verbose mode
-    if verboseMode:
-        sH.setLevel(logging.DEBUG)
-        sH.setFormatter(logging.Formatter(fmt=DEFAULT_LOG_DEBUG_FORMATTER))
-
-    # activate silent mode
-    if silentMode:
-        sH.setLevel(logging.ERROR)
-    # add it in the rootLogger
-    rootLogger.addHandler(sH)
-
-    #current logger
-    Logger = rootLogger
+    #load logger
+    logObj = customLogger('amc2moodle')
+    logObj.setupConsoleLogger(verbositylevel=verboseMode,
+                              silent=silentMode,
+                              txtinfo=amdlpkg.__version__)    
 
     # check input file
     fileInOk = False
@@ -132,12 +114,12 @@ def run():
         # remove existing log file
         if os.path.exists(logFile):
             os.remove(logFile)
-        # create handler for the log file
-        fileHandler = logging.FileHandler(logFile)
-        fileHandler.setLevel(logging.DEBUG)
-        fileHandler.setFormatter(logging.Formatter(DEFAULT_LOG_DEBUG_FORMATTER))
-        # add handler to the current list
-        rootLogger.addHandler(fileHandler)
+        # create file logger
+        logObj.setupFileLogger(filename=logFile,
+                               verbositylevel=2,
+                               txtinfo=amdlpkg.__version__)
+    #catch Logger
+    Logger = logObj.getLogger()
 
 
     if fileInOk:
@@ -151,6 +133,7 @@ def run():
         else:
             Logger.warning('Output file: %s - status: Already exists (will be overwritten)' % fileOut)
 
+    globalReturncode = 0
     # run conversion
     if fileInOk:
         a2m.amc2moodle(fileInput=fileIn, fileOutput=fileOut,
@@ -165,7 +148,9 @@ def run():
         if fileInOk:
             Logger.info("Log file of amc2moodle's run: {}".format(logFile))
         # exit with error status
-        sys.exit(1)
+        globalReturncode = 1
+    # exit with error status
+    sys.exit(globalReturncode)
 
 
 # Run autonomous

--- a/amc2moodle/amc2moodle/bin/amc2moodle
+++ b/amc2moodle/amc2moodle/bin/amc2moodle
@@ -67,8 +67,11 @@ def run():
                         action="version",
                         version="%(prog)s v{version}".format(version=amdlpkg.__version__))
     parser.add_argument("-v", "--verbose",
-                        help='''Show all log messages in CLI''',
-                        required=False, action="count")
+                        help='''Show all log messages in CLI. Use -vv for more verbosity.''',
+                        required=False, action="count",default=0)
+    parser.add_argument("--no-log-file",
+                        help='''Deactivate the log file.''',
+                        required=False, action="store_false")
     parser.add_argument("-s", "--silent",
                         help='''Hide all messages in CLI (log file is still written) (override verbosity)''',
                         required=False, action="store_true")
@@ -92,10 +95,7 @@ def run():
     magic_flag = not(args.magic_flag)
     silentMode = args.silent
     verboseMode = args.verbose
-
-    #adapt verbosemode
-    if not verboseMode:
-        verboseMode = 0
+    logFileMode = args.no_log_file
 
     #load logger
     logObj = customLogger('amc2moodle')
@@ -109,7 +109,7 @@ def run():
         fileInOk = os.path.exists(fileIn)
     
     # declare log file
-    if fileInOk:
+    if fileInOk and logFileMode:
         logFile = os.path.splitext(os.path.basename(fileIn))[0]+'_amc2moodle.log'
         # remove existing log file
         if os.path.exists(logFile):
@@ -140,15 +140,13 @@ def run():
                        keepFlag=keepFlag, catname=catname,
                        indentXML=indentFlag, usetempdir=tempDir,
                        magic_flag=magic_flag)
-        #info about the log
-    if fileInOk:
-        Logger.info("Log file of amc2moodle's run: {}".format(logFile))
-    else:
-        #info about the log
-        if fileInOk:
-            Logger.info("Log file of amc2moodle's run: {}".format(logFile))
+    else:        
         # exit with error status
         globalReturncode = 1
+    #info about the log
+    if fileInOk and logFileMode:
+        Logger.info("Log file of amc2moodle's run: {}".format(logFile))
+        
     # exit with error status
     sys.exit(globalReturncode)
 

--- a/amc2moodle/amc2moodle/bin/amc2moodle
+++ b/amc2moodle/amc2moodle/bin/amc2moodle
@@ -23,6 +23,7 @@ from amc2moodle.amc2moodle import amc2moodle_class as a2m
 import argparse
 import os
 import sys
+import logging
 
 
 def run():
@@ -61,10 +62,16 @@ def run():
                         help='''No use of system temporary directory, use
                                 input directory instead.''',
                         required=False, action="store_true")
-    parser.add_argument("-v", "--version",
+    parser.add_argument("-V", "--version",
                         help='''Show the current version of moodle2amc''',
                         action="version",
                         version="%(prog)s v{version}".format(version=amdlpkg.__version__))
+    parser.add_argument("-v", "--verbose",
+                        help='''Show all log messages in CLI''',
+                        required=False, action="store_true")
+    parser.add_argument("-s", "--silent",
+                        help='''Hide all messages in CLI (log file is still written) (override verbosity)''',
+                        required=False, action="store_true")
     parser.add_argument("--disable-magic",
                         help='''Disable magic comments (default : enable).''',
                         required=False, default=False, dest='magic_flag',
@@ -83,22 +90,66 @@ def run():
     tempDir = not args.notemp
     catname = args.catname
     magic_flag = not(args.magic_flag)
+    silentMode = args.silent
+    verboseMode = args.verbose
+
+    # DEFAULT
+    DEFAULT_LOG_FORMATTER = '%(asctime)s [%(levelname)s]: %(message)s '
+    DEFAULT_LOG_DEBUG_FORMATTER = '%(asctime)s-({}-%(name)s) [%(levelname)s]: %(message)s '.format(amdlpkg.__version__)
+    DEFAULT_FMT_TIME = '%H:%M:%S'
+    # create global logger
+    # logging.basicConfig(level=logging.DEBUG)
+    # load root logger
+    rootLogger = logging.getLogger('amc2moodle')
+    rootLogger.setLevel(logging.DEBUG)
+    # create basic stream logger
+    sH = logging.StreamHandler(stream=sys.stdout)
+    sH.setFormatter(logging.Formatter(fmt=DEFAULT_LOG_FORMATTER,datefmt=DEFAULT_FMT_TIME))
+    sH.setLevel(logging.INFO)    
+
+    # activate verbose mode
+    if verboseMode:
+        sH.setLevel(logging.DEBUG)
+        sH.setFormatter(logging.Formatter(fmt=DEFAULT_LOG_DEBUG_FORMATTER))
+
+    # activate silent mode
+    if silentMode:
+        sH.setLevel(logging.ERROR)
+    # add it in the rootLogger
+    rootLogger.addHandler(sH)
+
+    #current logger
+    Logger = rootLogger
 
     # check input file
     fileInOk = False
     if fileIn is not None:
         fileInOk = os.path.exists(fileIn)
+    
+    # declare log file
+    if fileInOk:
+        logFile = os.path.splitext(os.path.basename(fileIn))[0]+'_amc2moodle.log'
+        # remove existing log file
+        if os.path.exists(logFile):
+            os.remove(logFile)
+        # create handler for the log file
+        fileHandler = logging.FileHandler(logFile)
+        fileHandler.setLevel(logging.DEBUG)
+        fileHandler.setFormatter(logging.Formatter(DEFAULT_LOG_DEBUG_FORMATTER))
+        # add handler to the current list
+        rootLogger.addHandler(fileHandler)
+
 
     if fileInOk:
-        print('Input file: %s - status: %s' % (fileIn, "OK"))
+        Logger.debug('Input file: %s - status: %s' % (fileIn, "OK"))
     else:
-        print('Input file: %s - status: %s' % (fileIn, "does not exist"))
+        Logger.critical('Input file: %s - status: %s' % (fileIn, "does not exist"))
     if fileOut:
         fileOutOk = not os.path.exists(fileOut)
         if fileOutOk:
-            print('Output file: %s - status: Ok' % fileOut)
+            Logger.debug('Output file: %s - status: Ok' % fileOut)
         else:
-            print('Output file: %s - status: Already exists (will be overwritten)' % fileOut)
+            Logger.warning('Output file: %s - status: Already exists (will be overwritten)' % fileOut)
 
     # run conversion
     if fileInOk:
@@ -106,7 +157,13 @@ def run():
                        keepFlag=keepFlag, catname=catname,
                        indentXML=indentFlag, usetempdir=tempDir,
                        magic_flag=magic_flag)
+        #info about the log
+    if fileInOk:
+        Logger.info("Log file of amc2moodle's run: {}".format(logFile))
     else:
+        #info about the log
+        if fileInOk:
+            Logger.info("Log file of amc2moodle's run: {}".format(logFile))
         # exit with error status
         sys.exit(1)
 

--- a/amc2moodle/amc2moodle/convert.py
+++ b/amc2moodle/amc2moodle/convert.py
@@ -308,7 +308,7 @@ class AMCQuestionSimple(AMCQuestion):
         if len(barl) > 0:
             amc_bl_=dict(item.split("=") for item in barl[0].text.strip().split(","))
             amc_bl.update(amc_bl_)
-            Logger.debug("   local scoring:", amc_bl)
+            Logger.debug("   local scoring: {}".format(amc_bl))
             if (float(amc_bl['b']) < 1.):
                 Logger.warning("The grade of the good answser(s) may be < 100%, put b=1")
 
@@ -350,7 +350,7 @@ class AMCQuestionMult(AMCQuestionSimple):
             # partial scoring is provided
             amc_bml_ = dict(item.split("=") for item in barl[0].text.strip().split(","))
             amc_bml.update(amc_bml_)
-            Logger.debug("   local scoring :", amc_bml)
+            Logger.debug("   local scoring : {}".format(amc_bml))
             if (float(amc_bml['b']) < 1):
                 Logger.warning("The grade of the good answser(s) may be < 100%, put b=1")
 
@@ -877,7 +877,7 @@ class AMCQuiz:
             f.write(s)
 
         # summary
-        Logger.debug('\n')
+        Logger.debug(" ")
         Logger.debug(" > global 'shuffleanswers' is {}.".format(strtobool(self.options['shuffle_all'])))
         Logger.debug(" > global 'answerNumberingFormat' is '{}'.".format(self.options['answer_numbering_format']))
         Logger.debug(" > {} questions converted...".format(self.Qtot))
@@ -934,7 +934,7 @@ class AMCQuiz:
         if len(bars) > 0:
             # on découpe bar[0].text et on affecte les nouvelles valeurs par défaut
             amc_bs = dict(item.split("=") for item in bars[0].text.strip().split(","))
-            Logger.debug("baremeDefautS :", amc_bs)
+            Logger.debug("baremeDefautS : {}".format(amc_bs))
             if (float(amc_bs['b']) < 1):
                 Logger.warning("The grade of the good answser in question will be < 100%, put b=1")
             self.amc_bs.update(amc_bs)
@@ -945,7 +945,7 @@ class AMCQuiz:
         if len(barm) > 0:
             # on découpe bar[0].text et on affecte les nouvelles valeurs par défaut
             amc_bm = dict(item.split("=") for item in barm[0].text.strip().split(","))
-            Logger.debug("baremeDefautM :", amc_bm)
+            Logger.debug("baremeDefautM : {}".format(amc_bm))
             if (float(amc_bm['b']) < 1):
                 Logger.warning("The grade of the good answser(s) in questionmult may be < 100%, put b=1")
             self.amc_bm.update(amc_bm)

--- a/amc2moodle/amc2moodle/test.py
+++ b/amc2moodle/amc2moodle/test.py
@@ -24,6 +24,16 @@ import os
 import hashlib
 import unittest
 from lxml import etree
+import logging
+
+#manage logging
+logging.basicConfig(level=logging.DEBUG)
+Logger = logging.getLogger("tests_a2m")
+Logger.setLevel(logging.DEBUG)
+# Silence other loggers
+for log_name, log_obj in logging.Logger.manager.loggerDict.items():
+     if "tests_a2m" not in log_name and "amc2moodle" not in log_name:
+          log_obj.disabled = True
 
 # TODO complete test case for Numerical questions
 # TODO Test XML Schema Definition

--- a/amc2moodle/moodle2amc/_questions.py
+++ b/amc2moodle/moodle2amc/_questions.py
@@ -461,7 +461,8 @@ class QuestionNumerical(Question):
                 t = float(a.find('text').text)
                 f = float(a.attrib['fraction'])
                 if (a is not(ans)) and (f > 0) and (abs(t-target) < EPS):
-                    Logger.warning('  Detect two identical targets. \n Try to generate approx scoring..')
+                    Logger.warning('  Detect two identical targets.')
+                    Logger.warning('    Try to generate approx scoring..')
                     tolerance_approx = float(a.find('tolerance').text)
                     scoreapprox = f*SCOREEXACT/100
                     approx = round(tolerance_approx*(10**decimals))

--- a/amc2moodle/moodle2amc/_quiz.py
+++ b/amc2moodle/moodle2amc/_quiz.py
@@ -309,5 +309,5 @@ class Quiz:
                 - check the scoring
                 - ..."""
         for item in msg.split('\n'):
-            logging.warning(item)
+            Logger.info(item)
 

--- a/amc2moodle/moodle2amc/_quiz.py
+++ b/amc2moodle/moodle2amc/_quiz.py
@@ -25,6 +25,7 @@ import subprocess
 import os
 from ._questions import *
 from amc2moodle.utils.text import clean_q_name
+import logging
 
 
 # output latex File
@@ -32,7 +33,8 @@ LATEX_FILEOUT = 'out.tex'
 # xslt file
 XSLT_TEXRENDERER = os.path.join(os.path.dirname(__file__), 'struc2tex.xslt')
 
-
+# activate logger
+Logger = logging.getLogger(__name__)
 
 
 class Quiz:
@@ -83,7 +85,7 @@ class Quiz:
         # convert : convert(to str) converttofile
         amc, cat_dict = self._reshape()
         if debug:
-            print(etree.tostring(amc, pretty_print=True,
+            Logger.debug(etree.tostring(amc, pretty_print=True,
                                  encoding='utf8').decode('utf-8'))
         tex = self.texRendering(amc)
         # remove document root
@@ -236,7 +238,7 @@ class Quiz:
                 # for tex conversion, it is done in Question __init__
                 qname = clean_q_name(qname)
                 if qtype in SUPPORTED_QUESTION_TYPE:
-                        print("> Reshape question '{}' of type '{}'.".format(qname, qtype))
+                        Logger.debug("> Reshape question '{}' of type '{}'.".format(qname, qtype))
                         # if no encounter category name before this question,
                         # add the defaut catname in the cat_dict
                         if not(cat_dict):
@@ -246,9 +248,9 @@ class Quiz:
                         amc_q = CreateQuestion(qtype, question).transform(catname)
                         amc.append(amc_q)
                 else:
-                    print("> Question '{}' of type '{}' is not supported. Skipping.".format(qname, qtype))
+                    Logger.error("> Question '{}' of type '{}' is not supported. Skipping.".format(qname, qtype))
 
-        print('> done.')
+        Logger.info('> done.')
 
         # add footer
         footer = self._latex_footer(cat_dict)
@@ -286,7 +288,8 @@ class Quiz:
         latexFile : string
             full name of a latex file.
         """
-        command = "pdflatex {}".format(latexFile)
+        command = "pdflatex -interaction=nonstopmode -halt-on-error {}".format(latexFile)
+        Logger.debug('Run command {}'.format(command))
         status = subprocess.run(command.split(),
                                 stdout=subprocess.DEVNULL)
         return status
@@ -305,5 +308,5 @@ class Quiz:
               "  - strange html tags \n" +\
               "  - check the scoring \n" +\
               "  - ..."
-        print(msg)
+        Logger.warning(msg)
 

--- a/amc2moodle/moodle2amc/_quiz.py
+++ b/amc2moodle/moodle2amc/_quiz.py
@@ -299,14 +299,15 @@ class Quiz:
         """ Print ouput message.
         """
 
-        msg = "\nThe conversion is complete. Try to compile the tex file...\n" + \
-              "In case of trouble, you may need to check for :\n" + \
-              u"  - unicode character like euro € currency symbol  \n" + \
-              "  - latex special character like '{', '_', '&', ... \n" + \
-              "  - possible problems with embedded 'equation' environnement inside matjax delimiters:\n"\
-              "    ex :  $$\\begin{equation}... Remove '$$' in output TeX file  \n" + \
-              "  - strange html tags \n" +\
-              "  - check the scoring \n" +\
-              "  - ..."
-        Logger.warning(msg)
+        msg = """ The conversion is complete. Try to compile the tex file...
+                In case of trouble, you may need to check for :
+                - unicode character like euro € currency symbol  
+                - latex special character like '{', '_', '&', ... 
+                - possible problems with embedded 'equation' environnement inside matjax delimiters:
+                  ex :  $$\\begin{equation}... Remove '$$' in output TeX file
+                - strange html tags
+                - check the scoring
+                - ..."""
+        for item in msg.split('\n'):
+            logging.warning(item)
 

--- a/amc2moodle/moodle2amc/bin/moodle2amc
+++ b/amc2moodle/moodle2amc/bin/moodle2amc
@@ -18,7 +18,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-
+from amc2moodle.utils.customLogging import customLogger
 import amc2moodle as amdlpkg
 import amc2moodle.moodle2amc as mdl2amc
 import argparse
@@ -58,7 +58,7 @@ def run():
                         version="%(prog)s v{version}".format(version=amdlpkg.__version__))
     parser.add_argument("-v", "--verbose",
                         help='''Show all log messages in CLI''',
-                        required=False, action="store_true")
+                        required=False, action="count")
     parser.add_argument("-s", "--silent",
                         help='''Hide all messages in CLI (log file is still written) (override verbosity)''',
                         required=False, action="store_true")
@@ -79,34 +79,16 @@ def run():
     silentMode = args.silent
     verboseMode = args.verbose
 
-    # DEFAULT
-    DEFAULT_LOG_FORMATTER = '%(asctime)s [%(levelname)s]: %(message)s '
-    DEFAULT_LOG_DEBUG_FORMATTER = '%(asctime)s-({}-%(name)s) [%(levelname)s]: %(message)s '.format(amdlpkg.__version__)
-    DEFAULT_FMT_TIME = '%H:%M:%S'
+#adapt verbosemode
+    if not verboseMode:
+        verboseMode = 0
 
-    # create global logger
-    # logging.basicConfig(level=logging.DEBUG)
-    # load root logger
-    rootLogger = logging.getLogger('amc2moodle')
-    rootLogger.setLevel(logging.DEBUG)
-    # create basic stream logger
-    sH = logging.StreamHandler(stream=sys.stdout)
-    sH.setFormatter(logging.Formatter(fmt=DEFAULT_LOG_FORMATTER,datefmt=DEFAULT_FMT_TIME))
-    sH.setLevel(logging.INFO)    
+    #load logger
+    logObj = customLogger('amc2moodle')
+    logObj.setupConsoleLogger(verbositylevel=verboseMode,
+                              silent=silentMode,
+                              txtinfo=amdlpkg.__version__)    
 
-    # activate verbose mode
-    if verboseMode:
-        sH.setLevel(logging.DEBUG)
-        sH.setFormatter(logging.Formatter(fmt=DEFAULT_LOG_DEBUG_FORMATTER))
-
-    # activate silent mode
-    if silentMode:
-        sH.setLevel(logging.ERROR)
-    # add it in the rootLogger
-    rootLogger.addHandler(sH)
-
-    #current logger
-    Logger = rootLogger
 
     # check input file
     fileInOk = os.path.exists(fileIn)
@@ -117,12 +99,12 @@ def run():
         # remove existing log file
         if os.path.exists(logFile):
             os.remove(logFile)
-        # create handler for the log file
-        fileHandler = logging.FileHandler(logFile)
-        fileHandler.setLevel(logging.DEBUG)
-        fileHandler.setFormatter(logging.Formatter(DEFAULT_LOG_DEBUG_FORMATTER))
-        # add handler to the current list
-        rootLogger.addHandler(fileHandler)
+        # create file logger
+        logObj.setupFileLogger(filename=logFile,
+                               verbositylevel=2,
+                               txtinfo=amdlpkg.__version__)
+    #catch Logger
+    Logger = logObj.getLogger()
 
     if fileInOk:
         Logger.debug('Input file: %s - status: %s' % (fileIn, "OK"))

--- a/amc2moodle/moodle2amc/bin/moodle2amc
+++ b/amc2moodle/moodle2amc/bin/moodle2amc
@@ -57,8 +57,11 @@ def run():
                         action="version",
                         version="%(prog)s v{version}".format(version=amdlpkg.__version__))
     parser.add_argument("-v", "--verbose",
-                        help='''Show all log messages in CLI''',
-                        required=False, action="count")
+                        help='''Show all log messages in CLI. Use -vv for more verbosity.''',
+                        required=False, action="count",default=0)
+    parser.add_argument("--no-log-file",
+                        help='''Deactivate the log file.''',
+                        required=False, action="store_false")
     parser.add_argument("-s", "--silent",
                         help='''Hide all messages in CLI (log file is still written) (override verbosity)''',
                         required=False, action="store_true")
@@ -78,10 +81,7 @@ def run():
     
     silentMode = args.silent
     verboseMode = args.verbose
-
-#adapt verbosemode
-    if not verboseMode:
-        verboseMode = 0
+    logFileMode = args.no_log_file
 
     #load logger
     logObj = customLogger('amc2moodle')
@@ -94,7 +94,7 @@ def run():
     fileInOk = os.path.exists(fileIn)
 
     # declare log file
-    if fileInOk:
+    if fileInOk and logFileMode:
         logFile = os.path.splitext(os.path.basename(fileIn))[0]+'_moodle2amc.log'
         # remove existing log file
         if os.path.exists(logFile):
@@ -140,7 +140,7 @@ def run():
     else:
         globalReturncode = 1
     #info about the log
-    if fileInOk:
+    if fileInOk  and logFileMode:
         Logger.info("Log file of moodle2amc's run: {}".format(logFile))
     # exit with error status
     sys.exit(globalReturncode)

--- a/amc2moodle/moodle2amc/bin/moodle2amc
+++ b/amc2moodle/moodle2amc/bin/moodle2amc
@@ -24,6 +24,7 @@ import amc2moodle.moodle2amc as mdl2amc
 import argparse
 import os
 import sys
+import logging
 
 
 def run():
@@ -51,10 +52,16 @@ def run():
     parser.add_argument("--check",
                         help='''Check if LaTeX output compile (optional)''',
                         required=False, action="store_true")
-    parser.add_argument("--version",
+    parser.add_argument("-V","--version",
                         help='''Show the current version of moodle2amc''',
                         action="version",
                         version="%(prog)s v{version}".format(version=amdlpkg.__version__))
+    parser.add_argument("-v", "--verbose",
+                        help='''Show all log messages in CLI''',
+                        required=False, action="store_true")
+    parser.add_argument("-s", "--silent",
+                        help='''Hide all messages in CLI (log file is still written) (override verbosity)''',
+                        required=False, action="store_true")
     # parser.add_argument("-c", "--catname",  # nargs=1,
     #                     help='''Provide root category name (default 'amc').
     #                     Note that \\element{label} are used as
@@ -68,43 +75,94 @@ def run():
         fileIn = args.inputfile
     if args.output:
         fileOut = args.output
+    
+    silentMode = args.silent
+    verboseMode = args.verbose
+
+    # DEFAULT
+    DEFAULT_LOG_FORMATTER = '%(asctime)s [%(levelname)s]: %(message)s '
+    DEFAULT_LOG_DEBUG_FORMATTER = '%(asctime)s-({}-%(name)s) [%(levelname)s]: %(message)s '.format(amdlpkg.__version__)
+    DEFAULT_FMT_TIME = '%H:%M:%S'
+
+    # create global logger
+    # logging.basicConfig(level=logging.DEBUG)
+    # load root logger
+    rootLogger = logging.getLogger('amc2moodle')
+    rootLogger.setLevel(logging.DEBUG)
+    # create basic stream logger
+    sH = logging.StreamHandler(stream=sys.stdout)
+    sH.setFormatter(logging.Formatter(fmt=DEFAULT_LOG_FORMATTER,datefmt=DEFAULT_FMT_TIME))
+    sH.setLevel(logging.INFO)    
+
+    # activate verbose mode
+    if verboseMode:
+        sH.setLevel(logging.DEBUG)
+        sH.setFormatter(logging.Formatter(fmt=DEFAULT_LOG_DEBUG_FORMATTER))
+
+    # activate silent mode
+    if silentMode:
+        sH.setLevel(logging.ERROR)
+    # add it in the rootLogger
+    rootLogger.addHandler(sH)
+
+    #current logger
+    Logger = rootLogger
 
     # check input file
     fileInOk = os.path.exists(fileIn)
 
+    # declare log file
     if fileInOk:
-        print('Input file: %s - status: %s' % (fileIn, "OK"))
+        logFile = os.path.splitext(os.path.basename(fileIn))[0]+'_moodle2amc.log'
+        # remove existing log file
+        if os.path.exists(logFile):
+            os.remove(logFile)
+        # create handler for the log file
+        fileHandler = logging.FileHandler(logFile)
+        fileHandler.setLevel(logging.DEBUG)
+        fileHandler.setFormatter(logging.Formatter(DEFAULT_LOG_DEBUG_FORMATTER))
+        # add handler to the current list
+        rootLogger.addHandler(fileHandler)
+
+    if fileInOk:
+        Logger.debug('Input file: %s - status: %s' % (fileIn, "OK"))
     else:
-        print('Input file: %s - status: %s' % (fileIn, "does not exist"))
+        Logger.critical('Input file: %s - status: %s' % (fileIn, "does not exist"))
     if fileOut:
         fileOutOk = not os.path.exists(fileOut)
         if fileOutOk:
-            print('Output file: %s - status: Ok' % fileOut)
+            Logger.debug('Output file: %s - status: Ok' % fileOut)
         else:
-            print('Output file: %s - status: Already exists (will be overwritten)' % fileOut)
+            Logger.warning('Output file: %s - status: Already exists (will be overwritten)' % fileOut)
     else:
         fileOut = os.path.splitext(fileIn)[0] + '.tex'
-        print('Output file: %s - will be created.' % fileOut)
+        Logger.info('Output file: %s - will be created.' % fileOut)
 
+    globalReturncode = 0
     # run conversion
     if fileInOk:
-        print('============ Run conversion ============')
+        Logger.info('============ Run conversion ============')
         # create a quiz
         quiz = mdl2amc.Quiz(fileIn)
         # convert it
         quiz.convert(fileOut, debug)
         # test latex compilation
         if args.check:
-            print('============ Check output ==============')
+            Logger.info('============ Check output ==============')
             status = quiz.compileLatex(fileOut)
             if status.returncode != 0:
-                print('> pdflatex encounters Errors...')
-                sys.exit(status.returncode)
+                Logger.error('> pdflatex encounters Errors...')
+                globalReturncode = status.returncode
             else:
-                print('> pdflatex compile without Errors... OK')
+                Logger.info('> pdflatex compile without Errors... OK')
     else:
-        # exit with error status
-        sys.exit(1)
+        globalReturncode = 1
+    #info about the log
+    if fileInOk:
+        Logger.info("Log file of moodle2amc's run: {}".format(logFile))
+    # exit with error status
+    sys.exit(globalReturncode)
+    
 
 
 # Run autonomous

--- a/amc2moodle/moodle2amc/test.py
+++ b/amc2moodle/moodle2amc/test.py
@@ -24,7 +24,16 @@ from amc2moodle.moodle2amc import Quiz
 import os
 import unittest
 import pkgutil
+import logging
 
+#manage logging
+logging.basicConfig(level=logging.DEBUG)
+Logger = logging.getLogger("tests_a2m")
+Logger.setLevel(logging.DEBUG)
+# Silence other loggers
+for log_name, log_obj in logging.Logger.manager.loggerDict.items():
+    if "amc2moodle" not in log_name and "tests_a2m" not in log_name:
+        log_obj.disabled = True
 
 
 class TestSuite(unittest.TestCase):

--- a/amc2moodle/utils/calculatedParser.py
+++ b/amc2moodle/utils/calculatedParser.py
@@ -11,6 +11,7 @@ from abc import ABC, abstractmethod
 from pyparsing import Word, alphas, nums, alphas, alphanums, Char, oneOf,\
                       Suppress, Combine, Regex, Group, ZeroOrMore, Literal,\
                       Forward, Optional, ParseResults, _flatten
+import logging
 
 
 __all__ = ['CalculatedParserToFP', 'CalculatedParserFromFP',
@@ -110,6 +111,8 @@ abs,acos,add,and,array,asin,atan,atan2,bin,ceil,cos,
 '''
 
 
+# activate logger
+Logger = logging.getLogger(__name__)
 
 
 class CalculatedParser(ABC):
@@ -202,9 +205,7 @@ class CalculatedParser(ABC):
         # notpossible to use '_' in tex name
         out = tokens.name.replace('_', '')
         if out.isalpha() == False:
-            print("  Warning the variable '{}' is not".format(out),
-                  "compatible with LaTeX naming convention. You will need",
-                  "to change this name in our tex file.")
+            Logger.warning("  The variable '{}' is not compatible with LaTeX naming convention. You will need to change this name in our tex file.".format(out))
         return "\\" + out +' '
 
     @staticmethod
@@ -214,7 +215,7 @@ class CalculatedParser(ABC):
         # check for overflow
         x = float(tokens[0])
         if abs(x) > FP_MAX:
-            print('  Warning: this number {} will lead to overflow in FP.'.format(x))
+            Logger.warning(" This number {} will lead to overflow in FP.".format(x))
         # if floating point notation, need to convert to fixed point in FP
         if 'e' in tokens[0]:
             # conversion to fixed decimal format
@@ -313,10 +314,10 @@ class CalculatedParserToFP(CalculatedParser):
             out[0] = FP_EVAL_FUNCTION[tokens.name]
         # check that only valid expression are used
         elif tokens.name in FP_UNSUPPORTED:
-            print("Unsupported *function* '{}' by `fp` package in the expression.".format(tokens.name))
+            Logger.error("Unsupported *function* '{}' by `fp` package in the expression.".format(tokens.name))
             out = tokens
         else:
-            print("Unsupported *function* '{}' in the expression.".format(tokens.name))
+            Logger.error("Unsupported *function* '{}' in the expression.".format(tokens.name))
             out = tokens
         # print('In hook end :' , out)
         return out
@@ -454,10 +455,10 @@ class CalculatedParserFromFP(CalculatedParser):
             out[0] = MDL_FUNCTION[tokens.name]
         # check that only valid expression are used
         elif tokens.name in MDL_UNSUPPORTED:
-            print("Unsupported *function* '{}' by `moodle` interpreter in the expression.".format(tokens.name))
+            Logger.error("Unsupported *function* '{}' by `moodle` interpreter in the expression.".format(tokens.name))
             out = tokens
         else:
-            print("Unsupported *function* '{}' in the expression.".format(tokens.name))
+            Logger.error("Unsupported *function* '{}' in the expression.".format(tokens.name))
             out = tokens
         return out
 

--- a/amc2moodle/utils/customLogging.py
+++ b/amc2moodle/utils/customLogging.py
@@ -1,0 +1,135 @@
+import logging
+import sys
+
+# DEFAULT
+DEFAULT_LOG_BASIC_FORMATTER = '[%(levelname)-8s]: %(message)s '
+DEFAULT_LOG_VERBA_FORMATTER = '%(relativeCreated)dms [%(levelname)-8s]: %(message)s '
+DEFAULT_LOG_VERBB_FORMATTER = lambda x : '%(relativeCreated)dms-({}-%(name)s) [%(levelname)-8s]: %(message)s '.format(x)
+DEFAULT_LOG_VERBC_FORMATTER = '%(relativeCreated)dms-(%(name)s) [%(levelname)-8s]: %(message)s '
+DEFAULT_FMT_TIME = '%H:%M:%S'
+
+
+class customLogger:
+    """ 
+    Basic custom Logger management (load logger, remove consol/file logger, create console/file logger)
+    """
+
+    def __init__(self,
+        loggerName='custom'):
+        """
+        Load logger with loggerName ID and set level to DEBUG
+        """
+        self.rootLogger = logging.getLogger(loggerName)
+        self.rootLogger.setLevel(logging.DEBUG)
+
+    def removeConsoleLogger(self):
+        """
+        Remove all console Loggers
+        """
+        for hdlr in self.rootLogger.handlers[:]:
+            if isinstance(hdlr,logging.StreamHandler):
+                self.rootLogger.removeHandler(hdlr)
+    
+    def removeFileLogger(self):
+        """
+        Remove all file loggers
+        """
+        for hdlr in self.rootLogger.handlers[:]:
+            if isinstance(hdlr,logging.FileHandler):
+                self.rootLogger.removeHandler(hdlr) 
+
+
+    def setupConsoleLogger(self,
+        verbositylevel = 0,
+        silent = False,
+        txtinfo = None):
+        """
+        Create a console Logger with
+        - level of verbosity (verbositylevel from 0 to 2)
+        - silent mode (overrides verbosity)
+        - a specific word in the log message (using txtinfo)
+        """
+        #remove all console Logger
+        self.removeConsoleLogger()
+        #create Stream handler
+        sH = logging.StreamHandler(stream=sys.stdout)
+        #create basic logging level
+        basicLogLevel = logging.INFO
+        #silent mode overrides verbosity level
+        if silent:
+            verbositylevel = 0
+            basicLogLevel = logging.ERROR
+        #
+        if verbositylevel == 0:
+            #basic verbosity (no DEBUG, defaut)
+            sH.setFormatter(logging.Formatter(
+                fmt=DEFAULT_LOG_BASIC_FORMATTER
+            ))
+            sH.setLevel(basicLogLevel)
+        elif verbositylevel == 1:
+            #first level of verbosity (classic DEBUG level)
+            sH.setLevel(logging.DEBUG)
+            sH.setFormatter(
+                logging.Formatter(fmt=DEFAULT_LOG_VERBA_FORMATTER))
+        else:
+            #second level of verbosity (DEBUG level with details)
+            sH.setLevel(logging.DEBUG)
+            if txtinfo is not None:
+                fmtCustom = DEFAULT_LOG_VERBB_FORMATTER(txtinfo)
+            else:
+                fmtCustom = DEFAULT_LOG_VERBC_FORMATTER
+            sH.setFormatter(logging.Formatter(fmt=fmtCustom))
+        # add handler to the logger
+        self.rootLogger.addHandler(sH)           
+
+
+    def setupFileLogger(self,
+        filename,
+        verbositylevel = 2,
+        silent = False,
+        txtinfo = None):
+        """
+        Create a file Logger with
+        - the file specified by filename
+        - level of verbosity (verbositylevel from 0 to 2)
+        - silent mode (overrides verbosity)
+        - a specific word in the log message (using txtinfo)
+        """
+        #remove all file Loggers
+        self.removeFileLogger()
+        #create basic logging level
+        basicLogLevel = logging.INFO
+        #silent mode overrides verbosity level
+        if silent:
+            verbositylevel = 0
+            basicLogLevel = logging.ERROR
+        #create file handler
+        fH = logging.FileHandler(filename)
+        if verbositylevel == 0:
+            #basic verbosity (no DEBUG)
+            fH.setFormatter(logging.Formatter(
+                fmt=DEFAULT_LOG_BASIC_FORMATTER
+            ))
+            fH.setLevel(basicLogLevel)
+        elif verbositylevel == 1:
+            #first level of verbosity (classic DEBUG level)
+            fH.setLevel(logging.DEBUG)
+            fH.setFormatter(logging.Formatter(fmt=DEFAULT_LOG_VERBA_FORMATTER))
+        else:
+            #second level of verbosity (DEBUG level with details, default)
+            fH.setLevel(logging.DEBUG)
+            if txtinfo is not None:
+                fmtCustom = DEFAULT_LOG_VERBB_FORMATTER(txtinfo)
+            else:
+                fmtCustom = DEFAULT_LOG_VERBC_FORMATTER
+            fH.setFormatter(logging.Formatter(fmt=fmtCustom))
+        # add handler to the logger
+        self.rootLogger.addHandler(fH)
+
+    def getLogger(self):
+        """
+        Return root Logger
+        """
+        return self.rootLogger
+
+

--- a/amc2moodle/utils/flatex.py
+++ b/amc2moodle/utils/flatex.py
@@ -27,6 +27,10 @@ See http://www.gnu.org/licenses/gpl.txt for details.
 
 import os
 import re
+import logging
+
+# activate logger
+Logger = logging.getLogger(__name__)
 
 class Flatex:
     """ Merge all included tex files in one and remove magic comments.
@@ -149,5 +153,6 @@ class Flatex:
         """ Print log info about the expansion.
         """
         if self._magic_comments_number > 0:
-            print('  {} magic comments found,'.format(self._magic_comments_number),
-                  ' in {} tex files.'.format(len(self._included_files_list)))
+            Logger.info('  {0} magic comments found, in {1} tex files.'.format(
+                self._magic_comments_number,
+                len(self._included_files_list)))


### PR DESCRIPTION
New mechanism has been added in the whole package to deal with the management of the verbosity. `logging` package has been used to differentiate different kind of messages printed before using `print` method. 

**The new features are**

1. differentiate the type of log (debug, info, warning, error and critical)
2. with the binaries: 
    a. add verbosity options (`-v` for full verbosity and `-s` for silent mode)
    b. since a `.tex`or a `.xml` file is provided an associated log file will be created with suffix `_am2moodle.log` or `_moode2amc.log` (cleared at every run)
    c. the full verbosity is always given in the log file whatever the options are used with the binaries (notice that management of LateXML outputs could be improved due to the fact that LaTeXML uses only stderr)
    
**In the code:**

- many `print` syntaxes have been adapted to the use of `logging`
- a classification of the use of the levels of logging have been considered but can be improved
- one logger is call on every Python file/module but the name of the logger is only visible in debug mode or in log's files
- the current time (more accurate in debug mode), position of the log message in the sources (in debug mode) and level of logging are used on every log lines
- the outputs of LaTeXML is managed using`subprocess.Popen` and two threads (using `from concurrent.futures import ThreadPoolExecutor`) to simultaneously log `stdout` and `stderr` (notice that in my version of LaTeXML (`0.8.5; rev accf4d96`), the software only use `stderr`)
- `-V` argument for binaries has been introduced to show the version number
-  `-v` argument is now used to activate verbosity mode
- tests have been adapted but the loggers are reduced to the minimum (no log file, basic taggings on every lines)