### PR TITLE
Remove now useless manual installation of perl modules in macos ci.

### DIFF
--- a/.github/workflows/ci-mac-os.yml
+++ b/.github/workflows/ci-mac-os.yml
@@ -42,7 +42,7 @@ jobs:
         brew install libxslt
         
         # The list comes from lateXML docker file LaTeXML/tools/ci/Dockerfile
-        cpan -iT Archive::Zip DB_File File::Which Getopt::Long Image::Size IO::String JSON::XS LWP MIME::Base64 Parse::RecDescent Pod::Parser Text::Unidecode Test::More URI XML::LibXML XML::LibXSLT UUID::Tin
+        cpan -iT Archive::Zip DB_File File::Which Getopt::Long Image::Size IO::String JSON::XS LWP MIME::Base64 Parse::RecDescent Pod::Parser Text::Unidecode Test::More URI XML::LibXML XML::LibXSLT UUID::Tiny
         
         # install imagemagick
         brew install imagemagick

--- a/.github/workflows/ci-mac-os.yml
+++ b/.github/workflows/ci-mac-os.yml
@@ -32,24 +32,13 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
    
-    - name: Install the dependences
+    - name: Install the LaTeXML dependences
       run: |
         python -m pip install --upgrade pip
         
-        # install xml libraries and requirements for lateXML
-        # brew install cpanm
-        brew install libxml2     
-        brew install libxslt
-        
-        # The list comes from lateXML docker file LaTeXML/tools/ci/Dockerfile
-        cpan -iT Archive::Zip DB_File File::Which Getopt::Long Image::Size IO::String JSON::XS LWP MIME::Base64 Parse::RecDescent Pod::Parser Text::Unidecode Test::More URI XML::LibXML XML::LibXSLT UUID::Tiny
-        
-        # install imagemagick
+        # Install requirements for lateXML    
         brew install imagemagick
-
-        # install brew latex packages, libs and lateXML
         brew install --cask basictex
-
         brew install latexml
 
     - name: Update $PATH
@@ -113,16 +102,4 @@ jobs:
         name: test_moodle-bank-exemple_${{ matrix.python-version }}
         path: moodle-bank-exemple-output
 
-#    - name: Archive .
-#      if: ${{ always() }}
-#      uses: actions/upload-artifact@v1
-#      with:
-#        name: all_${{ matrix.python-version }}
-#        path: .
         
-        
-
-        
-
-    
-


### PR DESCRIPTION
After some investigation, the brew `LaTeXML`'s formula seems to works now without need of additional manual install.

TL;DR
The initial CI problem was due to `DB_file` perl module. The installation cashes on github since `libdb.dynlib` library was missing on the new environment. To fix the problem I add:
```
brew install berkeley-db
ln -s $(brew --prefix berkeley-db)/lib/libdb.dylib /usr/local/lib/libdb.dylib
```
...but finally, it is not required by `LaTeXML`. 

Few years ago, it was mandatory to install  by hand some perl modules before using `brew install latexml` but on the new environment it seems useless. That is why I remove all of them. It simpler and faster.

 
        

