### PR TITLE
Add new command line flag to enable --includestyles flag in LaTeXML call.

### DIFF
--- a/.github/workflows/ci-mac-os.yml
+++ b/.github/workflows/ci-mac-os.yml
@@ -47,8 +47,9 @@ jobs:
       
     - name: Add fonts (required by moodle2amc tests)
       run: |
+        # xstring is just required for testing --includestyles
         sudo tlmgr update --self
-        sudo tlmgr install collection-fontsrecommended bophook
+        sudo tlmgr install collection-fontsrecommended bophook xstring
         
     - name: Test latexml
       run: |

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Then the output LaTeX can be edited and included for creating amc exams. Example
 In case of problem, do not hesitate to ask for help on [discussions](https://github.com/nennigb/amc2moodle/discussions) or to create an [issues](https://github.com/nennigb/amc2moodle/issues). Both binaries (`amc2moodle` and `moodle2amc`) write full log in log files based on the name of the input file (`_amc2moodle.log` and `_amc2moodle.log` suffixes are added on these files).
   - 'convert: not authorized..' see ImageMagick policy.xml file see [here](https://stackoverflow.com/questions/52699608/wand-policy-error-error-constitute-c-readimage-412)
   - bugs with tikz-LaTeXML in texlive 2019/2020: please update the following `perl` modules `Parse::RecDescent`, `XML::LibXML` and `XML::LibXSLT` [here](https://github.com/brucemiller/LaTeXML/issues/1279) with `cpan` or `cpanm`in CLI.
+  - If LaTeXML doesn't know some LaTeX package and return `Warning:missing_file:package-name Can't find binding for package package-name`, you can try to invoque `amc2moodle` with `--includestyles` flag.
 
 ## Related Project
   - [auto-multiple-choice](https://www.auto-multiple-choice.net),  is a piece of software that can help you creating and managing multiple choice questionnaires (MCQ), with automated marking.

--- a/amc2moodle/amc2moodle/amc2moodle_class.py
+++ b/amc2moodle/amc2moodle/amc2moodle_class.py
@@ -1,21 +1,21 @@
 """
-    This file is part of amc2moodle, a convertion tool to recast quiz written
-    with the LaTeX format used by automuliplechoice 1.0.3 into the
-    moodle XML quiz format.
-    Copyright (C) 2016  Benoit Nennig, benoit.nennig@supmeca.fr
+This file is part of amc2moodle, a convertion tool to recast quiz written
+with the LaTeX format used by automuliplechoice 1.0.3 into the
+moodle XML quiz format.
+Copyright (C) 2016  Benoit Nennig, benoit.nennig@supmeca.fr
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 from typing import Callable
@@ -34,9 +34,9 @@ from concurrent.futures import ThreadPoolExecutor
 # activate logger
 Logger = logging.getLogger(__name__)
 
+
 def checkTools(show=True):
-    """ Check if the required Tools are available.
-    """
+    """Check if the required Tools are available."""
     # Wand Python module
     wand_loader = util.find_spec('wand')
     wandOk = wand_loader is not None
@@ -58,43 +58,42 @@ def checkTools(show=True):
 
 
 def getFilename(fileIn):
-    """ Get the filename without path.
-    """
+    """Get the filename without path."""
     return os.path.basename(fileIn)
 
 
 def getPathFile(fileIn):
-    """ Get the path of a file without.
-    """
+    """Get the path of a file without."""
     dirname = os.path.dirname(fileIn)
     if not dirname:
         dirname = '.'
     return dirname
 
-def writePipeOnOutput(process,streamIn,output:Callable):
-    """ Write the stream from a pipe through an output
-    during process executed by subprocess.Popen
+
+def writePipeOnOutput(process, streamIn, output: Callable):
+    """Write the stream from a pipe through an output during process executed
+    by subprocess.Popen
     """
     while process.poll() is None:
         msg = streamIn.readline().strip()
-        if msg !="":
+        if msg != "":
             output(msg)
     # write the rest from the buffer
     msg = streamIn.read().strip()
-    if msg !="":
+    if msg != "":
         output(msg)
 
 
 class amc2moodle:
-    """ Main class to invoke LaTeX to moodle XML conversion.
-    """
+    """Main class to invoke LaTeX to moodle XML conversion."""
+
     # tag for magic comments
     magictag = '%amc2moodle '
 
     def __init__(self, fileInput, fileOutput=None, keepFlag=False,
                  catname='amc', indentXML=False, usetempdir=True,
                  magic_flag=True, cleanXML=False, deb=0, include_styles=False):
-        """ Initialize the object.
+        """Initialize the object.
 
         Parameters
         ----------
@@ -116,7 +115,7 @@ class amc2moodle:
             Allow LaTeXML to load raw *.sty file. The default is False.
         deb : int, optional
             Store all intermediate file for debugging.
-        
+
         Returns
         -------
         None.
@@ -168,12 +167,11 @@ class amc2moodle:
             # Show summury of all loaded parameters
             self.showData()
 
-        #run the building of the xml file for Moodle
+        # run the building of the xml file for Moodle
         self.runBuilding()
 
     def cleanUpTemp(self):
-        """ Clean-up temp directory created by tempfile.TemporaryDirectory().
-        """
+        """Clean-up temp directory created by tempfile.TemporaryDirectory()."""
         Logger.debug(' > Clean-up tempfile.')
         self.tempdir.cleanup()
         # remove magictex temp file
@@ -181,9 +179,8 @@ class amc2moodle:
             os.unlink(self.magictex)
 
     def showData(self):
-        """ Show loaded parameters.
-        """
-        disable = {True:'enable', False:'disable'}
+        """Show loaded parameters."""
+        disable = {True: 'enable', False: 'disable'}
         Logger.debug('====== Parameters ======')
         Logger.debug(' > path input TeX: %s' % getPathFile(self.inputtex))
         Logger.debug(' > input TeX file: %s' % getFilename(self.inputtex))
@@ -196,8 +193,7 @@ class amc2moodle:
         Logger.debug(' > magic comments: %s' % disable[self.magic_flag])
 
     def endMessage(self):
-        """ Show end message explaining moodle import procedure.
-        """
+        """Show end message explaining moodle import procedure."""
         msg = """ File converted.
 
             For import into moodle :
@@ -212,10 +208,7 @@ class amc2moodle:
             Logger.info(item)
 
     def removeMagicComment(self):
-        """ Remove magic comments prefix to enable amc2moodle dedicated LaTeX
-        commands.
-        """
-
+        """Remove magic comments prefix to enable amc2moodle dedicated LaTeX commands."""
         pathin = getPathFile(self.inputtex)
         prefix = os.path.splitext(getFilename(self.inputtex))[0] + '_'
 
@@ -235,10 +228,8 @@ class amc2moodle:
         texpand.expand()
         texpand.report()
 
-
     def runLaTeXML(self):
-        """ Run LaTeXML on the input TeX file.
-        """
+        """Run LaTeXML on the input TeX file."""
         # run LaTeXML on magictex file
         Logger.info(' > Running LaTeXML conversion')
         # LoggerXML = logging.getLogger('LaTexML')
@@ -265,21 +256,20 @@ class amc2moodle:
             # all outputs will be written in debug log
             with ThreadPoolExecutor(2) as pool:
                 rstdout = pool.submit(writePipeOnOutput,
-                        latexmlProcess,
-                        latexmlProcess.stdout,
-                        Logger.debug)
+                                      latexmlProcess,
+                                      latexmlProcess.stdout,
+                                      Logger.debug)
                 rstderr = pool.submit(writePipeOnOutput,
-                        latexmlProcess,
-                        latexmlProcess.stderr,
-                        Logger.debug)
+                                      latexmlProcess,
+                                      latexmlProcess.stderr,
+                                      Logger.debug)
                 rstdout.result()
                 rstderr.result()
-        #latexmlProcess.wait()
+        # latexmlProcess.wait()
         return latexmlProcess.returncode == 0
 
     def runXMLindent(self):
-        """ Run XML indentation with subprocess.
-        """
+        """Run XML indentation with subprocess."""
         # check for xmlindent
         xmlindentwhich = subprocess.run(['which', 'xmlindent'])
         xmlindentOk = xmlindentwhich.returncode == 0
@@ -299,9 +289,7 @@ class amc2moodle:
                            stdout=subprocess.DEVNULL)
 
     def runCleanXML(self):
-        """ Clean final XML file remove "%" added by LaTeXML at end of lines
-        (EXPERIMENTAL).
-        """
+        """Clean final XML file remove "%" added by LaTeXML at end of lines (EXPERIMENTAL)."""
         pattern = '%\n'
         Logger.warning("Caution: cleaning XML file is experimental")
         # copy output file and remove '%\n' (a temporary file will be used and deleted)
@@ -325,8 +313,7 @@ class amc2moodle:
         Logger.info(" > Cleaning: done, with {} replacements.".format(nreplacement))
 
     def runBuilding(self):
-        """ Build the xml file for Moodle quizz.
-        """
+        """Build the xml file for Moodle quizz."""
         Logger.info('====== Build XML =======')
         # remove magic comment, return magictex
         if self.magic_flag:

--- a/amc2moodle/amc2moodle/amc2moodle_class.py
+++ b/amc2moodle/amc2moodle/amc2moodle_class.py
@@ -93,7 +93,7 @@ class amc2moodle:
 
     def __init__(self, fileInput, fileOutput=None, keepFlag=False,
                  catname='amc', indentXML=False, usetempdir=True,
-                 magic_flag=True, cleanXML=False, deb=0):
+                 magic_flag=True, cleanXML=False, deb=0, include_styles=False):
         """ Initialize the object.
 
         Parameters
@@ -111,10 +111,12 @@ class amc2moodle:
         usetempdir : bool, optional
             Store all intermediate file in temp directory. The default is True.
         magic_flag : bool, optional
-            Enable magic comment.The default is True.
+            Enable magic comment. The default is True.
+        include_styles : bool, optional
+            Allow LaTeXML to load raw *.sty file. The default is False.
         deb : int, optional
             Store all intermediate file for debugging.
-
+        
         Returns
         -------
         None.
@@ -130,6 +132,7 @@ class amc2moodle:
         self.tempxmlfile = 'tex2xml.xml'
         self.indentXML = indentXML
         self.cleanXML = cleanXML
+        self.include_styles = include_styles
 
         # check required tools
         if not checkTools(show=True):
@@ -239,20 +242,23 @@ class amc2moodle:
         # run LaTeXML on magictex file
         Logger.info(' > Running LaTeXML conversion')
         # LoggerXML = logging.getLogger('LaTexML')
-        #TODO: caution with 'universal_newlines=' (new syntax from Python 3.7: text=)
+        # TODO: caution with 'universal_newlines=' (new syntax from Python 3.7: text=)
+        options = ['--noparse',
+                   '--nocomments', ]
+        if self.include_styles:
+            options.append('--includestyles')
         with subprocess.Popen([
-            'latexml',
-            '--noparse',
-            '--nocomments',
-            '--path=%s' % os.path.dirname(__file__),
-            '--dest=%s' % self.tempxmlfile,
-            self.magictex],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            universal_newlines=True) as latexmlProcess:
-            #while latexmlProcess.poll() is None:
+                'latexml',
+                *options,
+                '--path=%s' % os.path.dirname(__file__),
+                '--dest=%s' % self.tempxmlfile,
+                self.magictex],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                universal_newlines=True) as latexmlProcess:
+            # while latexmlProcess.poll() is None:
             #    Logger.debug(latexmlProcess.stdout.read())
-            #writePipeOnOutput(latexmlProcess,latexmlProcess.stderr,Logger.debug)
+            # writePipeOnOutput(latexmlProcess,latexmlProcess.stderr,Logger.debug)
 
             # write stdout and stderr in parallel to the right logging outputs
             # caution LaTeXML uses only STDERR... (version 0.8.5)

--- a/amc2moodle/amc2moodle/bin/amc2moodle
+++ b/amc2moodle/amc2moodle/bin/amc2moodle
@@ -82,6 +82,10 @@ def run():
                         help='''Disable magic comments (default : enable).''',
                         required=False, default=False, dest='magic_flag',
                         action="store_true")
+    parser.add_argument("--includestyles",
+                        help='''Allow LaTeXML to load raw *.sty file (default : False).''',
+                        required=False, default=False, dest='include_styles',
+                        action="store_true")
 
     # Get input args
     args = parser.parse_args()
@@ -100,6 +104,7 @@ def run():
     verboseMode = args.verbose
     cleanXML=args.exp
     logFileMode = args.no_log_file
+    include_styles = args.include_styles
 
     #load logger
     logObj = customLogger('amc2moodle')
@@ -143,7 +148,8 @@ def run():
         a2m.amc2moodle(fileInput=fileIn, fileOutput=fileOut,
                        keepFlag=keepFlag, catname=catname,
                        indentXML=indentFlag, usetempdir=tempDir,
-                       magic_flag=magic_flag, cleanXML=cleanXML)
+                       magic_flag=magic_flag, cleanXML=cleanXML,
+                       include_styles=include_styles)
     else:        
         # exit with error status
         globalReturncode = 1

--- a/amc2moodle/amc2moodle/test.py
+++ b/amc2moodle/amc2moodle/test.py
@@ -451,6 +451,41 @@ class TestSuiteElement(unittest.TestCase):
                        deb=0)
 
 
+class TestSuiteStyles(unittest.TestCase):
+    """Check if `include_styles` options works as expected."""
+
+    @staticmethod
+    def check_error(fileOut):
+        """Parse ouput file `fileOut` and check if `ERROR` are present."""
+        is_error = False
+        with open(fileOut, 'r') as f:
+            for line in f.readlines():
+                if 'ERROR' in line:
+                    print(line)
+                    is_error = True
+        return is_error
+
+    def test_with_include(self):
+        """Tests `include_styles` options works as expected.
+
+        Error should be REMOVED when `include_styles` is switch on.
+        """
+        # define i/o file
+        fileIn = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                              "test/includestyles.tex"))
+        fileOut = os.path.abspath('./test_includestyles.xml')
+        # convert to xml
+        a2m.amc2moodle(fileInput=fileIn,
+                       fileOutput=fileOut,
+                       keepFlag=False,
+                       catname='temp',
+                       deb=0,
+                       include_styles=True)
+        is_error = self.check_error(fileOut)
+        # Error should be removed with the flag on
+        self.assertFalse(is_error)
+
+
 if __name__ == '__main__':
     # run unittest test suite
     Logger.info('> Running tests...')

--- a/amc2moodle/amc2moodle/test/includestyles.tex
+++ b/amc2moodle/amc2moodle/test/includestyles.tex
@@ -1,0 +1,18 @@
+\documentclass[a4paper]{article}
+\usepackage[utf8x]{inputenc}    
+\usepackage[T1]{fontenc}
+\usepackage{xstring}
+\usepackage[francais,bloc,completemulti,correc,ordre]{automultiplechoice}    
+
+\begin{document}
+
+\element{use:xtring}{
+\begin{question}{q:xstring}\QuestionIndicative
+Just test if \texttt{xstring} can be loaded by LaTeXML.
+What you think ?
+\def\mystr{Hello world}
+\IfSubStr{llo}{\mystr}{Yes}{No}
+\end{question}
+}
+
+\end{document}


### PR DESCRIPTION
Add new command line flag to enable `--includestyles` flag in LaTeXML call.
It allows LaTeXML to load raw *.sty file (the default is False).
This option is useful if the quiz uses a package without LaTeXML bindings (if LaTeXML can parse it).

basic usage:
```
amc2moodle --includestyles myfile.tex
```
This PR also add a dependance for test to `xstring` latex package.