### PR TITLE
Fix python version for new ubuntu-latest runner.

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -22,8 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
-        # python-version: [3.5]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
+        # unsupported version on ubuntu-latest 3.5, 3.6
+        # see https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
         # unsupported version on ubuntu-latest 3.5, 3.6
         # see https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md
     # Steps represent a sequence of tasks that will be executed as part of the job


### PR DESCRIPTION
  - Python 3.6 is not present in default installation.
  - Add 3.10 and 3.11 to the test matrix