### PR TITLE
Update github action version.

### DIFF
--- a/.github/workflows/ci-mac-os.yml
+++ b/.github/workflows/ci-mac-os.yml
@@ -26,9 +26,9 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3.1.0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
    
@@ -36,7 +36,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         
-        # Install requirements for lateXML    
+        # Install requirements for lateXML 
+        brew update   
         brew install imagemagick
         brew install --cask basictex
         brew install latexml

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -28,9 +28,9 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3.1.0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     


### PR DESCRIPTION
GitHub warn about depreciated feature. This PR update version of the following internal github action  : 
    * setup-python to v4
    * checkout to v3.1.0
   
This PR also fix a missing `brew update` in macOS workflow, causing a recent failure (dead link in basictex).