### PR TITLE
Update action version in CI

### DIFF
--- a/.github/workflows/ci-mac-os.yml
+++ b/.github/workflows/ci-mac-os.yml
@@ -14,7 +14,8 @@ on:
   schedule:
     # * is a special character in YAML so you have to quote this string
     # run at 02:01 on every 15th day-of-month.
-    - cron:  '1 2 */15 * *'    
+    - cron:  '1 2 */15 * *'
+    
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -29,9 +30,9 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v3.1.0
+    - uses: actions/checkout@main
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@main
       with:
         python-version: ${{ matrix.python-version }}
    
@@ -68,7 +69,7 @@ jobs:
     - name: Test amc2moodle
       run: |
         python -m amc2moodle.amc2moodle.test
-
+        
     - name: Test moodle2amc
       run: |
         # add automultiplechoice.sty local copy to LaTeX PATH (for this step)
@@ -83,14 +84,14 @@ jobs:
     # amc2moodle
     - name: Archive XML test output of amc2moodle (without tikz)
       if: ${{ always() }}
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@main
       with:
         name: test_notikz_${{ matrix.python-version }}
         path: test_notikz.xml    
     
     - name: Archive XML test output of amc2moodle (with tikz)
       if: ${{ always() }}
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@main
       with:
         name: test_tikz_${{ matrix.python-version }}
         path: test_tikz.xml
@@ -103,7 +104,7 @@ jobs:
         
     - name: Archive LaTeX test output (moodle2amc)
       if: ${{ always() }}
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@main
       with:
         name: test_moodle-bank-exemple_${{ matrix.python-version }}
         path: moodle-bank-exemple-output

--- a/.github/workflows/ci-mac-os.yml
+++ b/.github/workflows/ci-mac-os.yml
@@ -22,7 +22,10 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.8, '3.10', '3.11']
+    env:
+      # set env variable for Wand
+      MAGICK_HOME: '/opt/homebrew'
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -60,11 +63,12 @@ jobs:
     - name: Install amc2moodle
       run: |
         # add -e to have write access for test. TODO : change with temp file
-        pip install -e .
+        pip install -e .             
     
     - name: Test amc2moodle
       run: |
         python -m amc2moodle.amc2moodle.test
+
     - name: Test moodle2amc
       run: |
         # add automultiplechoice.sty local copy to LaTeX PATH (for this step)

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -28,9 +28,9 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v3.1.0
+    - uses: actions/checkout@main
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@main
       with:
         python-version: ${{ matrix.python-version }}
     
@@ -78,14 +78,14 @@ jobs:
     # amc2moodle
     - name: Archive XML test output of amc2moodle (without tikz)
       if: ${{ always() }}
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@main
       with:
         name: test_notikz_${{ matrix.python-version }}
         path: test_notikz.xml    
     
     - name: Archive XML test output of amc2moodle (with tikz)
       if: ${{ always() }}
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@main
       with:
         name: test_tikz_${{ matrix.python-version }}
         path: test_tikz.xml
@@ -98,7 +98,7 @@ jobs:
 
     - name: Archive LaTeX test output (moodle2amc)
       if: ${{ always() }}
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@main
       with:
         name: test_moodle-bank-exemple_${{ matrix.python-version }}
         path: moodle-bank-exemple-output


### PR DESCRIPTION
  - Update action version in CI (ubuntu and macos). Instead of version like before, I suggest to use `main` version for _auto_ update.
  - Fix MagickWand lib path problem in macos with MAGICK_HOME env variable

The macos script is still expected to fails because of new LaTeXML version #80 
This issue will be sort by the next PR.