### PR TITLE
add new workflow to publish on PyPI and generate releases on github

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,11 +1,14 @@
 name: 'Build amc2moodle container'
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Publish Python 🐍 distribution 📦 to PyPI and create a github release"]
+    types: [completed]
+  # push:
     # branches:
     #   - 'master'
-    tags:
-      - 'v*'
+    # tags:
+    #   - 'v*'
 
 
 jobs:

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -1,45 +1,21 @@
-name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
+name: Publish Python 🐍 distribution 📦 to PyPI and create a github release
 
 on:
-  workflow_run:
-    workflows: [CI-mac-os,CI-Ubuntu]
-    types: [completed]
-  # push:
-  #   branches:
-  #     - 'main'
-  #   tags:
-  #     - 'v*'
-  
+  push:
+    tags:
+      - 'v*'
+
 jobs:
-  allowrun:
-    name: Check if the workflow can be ran
+  build:
+    name: Build distribution 📦
     runs-on: ubuntu-latest
-    outputs:
-      status: ${{ steps.info.outputs.status }}
-    steps:
-    - name: Check if head branch has version tag
+    steps:   
+    - name: Check if head branch has a valid version tag
       uses: actions-ecosystem/action-regex-match@v2
       id: regex-match
       with:
-        text: ${{ github.event.workflow_run.head_branch }}
-        regex: '^v[0-9]+'
-    - name: Show info
-      id: info
-      run: |
-        echo ${{ steps.regex-match.outputs.match }}
-        echo "status=${{(github.event.workflow_run.conclusion == 'success') && (steps.regex-match.outputs.match != '') }}" >> "$GITHUB_OUTPUT"
-  build:
-    name: Build distribution 📦
-    needs: allowrun
-    runs-on: ubuntu-latest
-    if: ${{ needs.allowrun.outputs.status == 'true' }}
-    steps:   
-    - name: Show event info
-      run: |
-        echo "value: ${{ needs.allowrun.outputs.status }}"
-        echo "Event info: ${{ toJson(github.event) }}"
-        echo "Workflow run info: ${{ toJson(github.event.workflow_run) }}"
-        echo "Workflow job info: ${{ github.event.workflow_run.head_branch }}"
+        text: ${{ github.ref_name }}
+        regex: '^v[0-9]+.[0-9]+.[0-9]+'  # should we add final letters like 'beta'
     - uses: actions/checkout@main
     - name: Set up Python
       uses: actions/setup-python@main
@@ -47,10 +23,22 @@ jobs:
         python-version: "3.12"
     - name: Install hatch
       run: >-
-        python3 -m
-        pip install
-        hatch
-        --user
+        python3 -m pip install hatch --user
+    - name: Compare the tag and the package version
+      env: 
+        MATCH: ${{ steps.regex-match.outputs.match }}
+      run: |
+        echo "trig on push with:" ${{ github.ref }}  # when trig on tag, contains the tag
+        echo "full branch name": ${{ github.ref_name }}
+        echo "package tag:" $(hatch version)
+        echo "matched git tag:" $MATCH
+        if [[ v$(hatch version) == $MATCH ]]; then   # In version.py no 'v' prefix
+          echo "tags are identical, continue..."
+          exit 0;
+        else 
+          echo "tags are different. Stop."
+          exit 1;
+        fi
     - name: Build a binary wheel and a source tarball
       run: hatch build    
     - name: Store the distribution packages
@@ -58,14 +46,51 @@ jobs:
       with:
         name: python-package-distributions
         path: dist/
- 
 
+  check-wheels:
+    name: Install and test from the wheels
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@main
+      with:
+        python-version: "3.12"
+    - name: Install the dependences
+      run: |
+        python -m pip install --upgrade pip
+        # install ubuntu package
+        sudo apt-get update
+        # need to add ghostscript explicitly (only 'recommanded' by imagemagick package)
+        # but 'libmagickwand-dev' is installed
+        sudo apt-get install ghostscript imagemagick
+        # move policy file
+        sudo mv /etc/ImageMagick-6/policy.xml /etc/ImageMagick-6/policy.xml.off
+        # texlive-fonts-recommended (bophook in texlive-latex-extra) required by moodle2amc test
+        sudo apt-get install texlive-latex-recommended texlive-pictures texlive-fonts-recommended texlive-latex-extra
+        # add libtext-unidecode-perl to fix bug in deb package : https://github.com/brucemiller/LaTeXML/issues/1022
+        sudo apt-get install libtext-unidecode-perl
+        sudo apt-get install latexml
+        sudo apt-get install xmlindent        
+    - name: Download all the wheel
+      uses: actions/download-artifact@main
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Install the wheel
+      run: |
+        ls -lrt
+        pip install pytest
+        pip install dist/amc2moodle*.whl    
+    - name: Test the install from wheel
+      run: pytest --pyargs amc2moodle
+ 
   github-release:
     name: >-
       Sign the Python 🐍 distribution 📦 with Sigstore
       and upload them to GitHub Release
     needs:
-    - build
+    - check-wheels
     runs-on: ubuntu-latest
 
     permissions:
@@ -98,13 +123,12 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
       run: >-
         gh release create        
-        '${{ github.event.workflow_run.head_branch }}'
+        '${{ github.ref_name }}'
         --repo '${{ github.repository }}'
         --generate-notes
-        --title 'amc2moodle ${{ github.event.workflow_run.head_branch }}'
+        --title 'amc2moodle ${{ github.ref_name }}'
 
         ## '${{ github.ref_name }}'
-
 
     - name: Upload artifact signatures to GitHub Release
       env:
@@ -114,38 +138,38 @@ jobs:
       # sigstore-produced signatures and certificates.
       run: >-
         gh release upload
-        '${{ github.event.workflow_run.head_branch }}' dist/**
+        '${{ github.ref_name }}' dist/**
         --repo '${{ github.repository }}'
 
-  publish-to-testpypi:
-    name: Publish Python 🐍 distribution 📦 to TestPyPI
-    needs:
-    - build
-    runs-on: ubuntu-latest
+  # publish-to-testpypi:
+  #   name: Publish Python 🐍 distribution 📦 to TestPyPI
+  #   needs:
+  #   - build
+  #   runs-on: ubuntu-latest
 
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/amc2moodle
+  #   environment:
+  #     name: testpypi
+  #     url: https://test.pypi.org/p/amc2moodle
 
-    permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
+  #   permissions:
+  #     id-token: write  # IMPORTANT: mandatory for trusted publishing
 
-    steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-    - name: Publish distribution 📦 to TestPyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        repository-url: https://test.pypi.org/legacy/
+  #   steps:
+  #   - name: Download all the dists
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       name: python-package-distributions
+  #       path: dist/
+  #   - name: Publish distribution 📦 to TestPyPI
+  #     uses: pypa/gh-action-pypi-publish@release/v1
+  #     with:
+  #       repository-url: https://test.pypi.org/legacy/
 
   publish-to-pypi:
     name: >-
       Publish Python 🐍 distribution 📦 to PyPI
-    needs:
-    - publish-to-testpypi
+    # needs:
+    # - publish-to-testpypi
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -1,0 +1,163 @@
+name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
+
+on:
+  workflow_run:
+    workflows: [CI-mac-os,CI-Ubuntu]
+    types: [completed]
+  # push:
+  #   branches:
+  #     - 'main'
+  #   tags:
+  #     - 'v*'
+  
+jobs:
+  allowrun:
+    name: Check if the workflow can be ran
+    runs-on: ubuntu-latest
+    outputs:
+      status: ${{ steps.info.outputs.status }}
+    steps:
+    - name: Check if head branch has version tag
+      uses: actions-ecosystem/action-regex-match@v2
+      id: regex-match
+      with:
+        text: ${{ github.event.workflow_run.head_branch }}
+        regex: '^v[0-9]+'
+    - name: Show info
+      id: info
+      run: |
+        echo ${{ steps.regex-match.outputs.match }}
+        echo "status=${{(github.event.workflow_run.conclusion == 'success') && (steps.regex-match.outputs.match != '') }}" >> "$GITHUB_OUTPUT"
+  build:
+    name: Build distribution 📦
+    needs: allowrun
+    runs-on: ubuntu-latest
+    if: ${{ needs.allowrun.outputs.status == 'true' }}
+    steps:   
+    - name: Show event info
+      run: |
+        echo "value: ${{ needs.allowrun.outputs.status }}"
+        echo "Event info: ${{ toJson(github.event) }}"
+        echo "Workflow run info: ${{ toJson(github.event.workflow_run) }}"
+        echo "Workflow job info: ${{ github.event.workflow_run.head_branch }}"
+    - uses: actions/checkout@main
+    - name: Set up Python
+      uses: actions/setup-python@main
+      with:
+        python-version: "3.12"
+    - name: Install hatch
+      run: >-
+        python3 -m
+        pip install
+        hatch
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: hatch build    
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@main
+      with:
+        name: python-package-distributions
+        path: dist/
+ 
+
+  github-release:
+    name: >-
+      Sign the Python 🐍 distribution 📦 with Sigstore
+      and upload them to GitHub Release
+    needs:
+    - build
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write  # IMPORTANT: mandatory for making GitHub Releases
+      id-token: write  # IMPORTANT: mandatory for sigstore
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@main
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Sign the dists with Sigstore
+      uses: sigstore/gh-action-sigstore-python@v3.0.0
+      with:
+        inputs: >-
+          ./dist/*.tar.gz
+          ./dist/*.whl
+    # - name: Release
+    #   uses: softprops/action-gh-release@master
+    #   if: startsWith(github.ref, 'refs/tags/')
+    #   with:
+    #     name: amc2moodle release ${{ github.event.release.tag_name }}
+    #     prerelease: false
+    #     files: dist/*
+    #   env:
+    #      GITHUB_TOKEN: ${{ github.token }}
+    - name: Create GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: >-
+        gh release create        
+        '${{ github.event.workflow_run.head_branch }}'
+        --repo '${{ github.repository }}'
+        --generate-notes
+        --title 'amc2moodle ${{ github.event.workflow_run.head_branch }}'
+
+        ## '${{ github.ref_name }}'
+
+
+    - name: Upload artifact signatures to GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      # Upload to GitHub Release using the `gh` CLI.
+      # `dist/` contains the built packages, and the
+      # sigstore-produced signatures and certificates.
+      run: >-
+        gh release upload
+        '${{ github.event.workflow_run.head_branch }}' dist/**
+        --repo '${{ github.repository }}'
+
+  publish-to-testpypi:
+    name: Publish Python 🐍 distribution 📦 to TestPyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/amc2moodle
+
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+
+  publish-to-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    needs:
+    - publish-to-testpypi
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/amc2moodle  # Replace <package-name> with your PyPI project name
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
New complete workflow for publishing based on the [Python Packaging User Guide](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/).

Note that:
 * the publishing process will work only if the tests ran with success AND if the version tags have been pushed
 * the [trusted publishing](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#configuring-trusted-publishing) has been set in [PyPI](https://pypi.org/manage/account/publishing/) and [PyPI test](https://test.pypi.org/manage/account/publishing/).
 * some parts especially for automatic generation of github release could be adapted (use `gh` command)
 * some tests must be ran to check the process (the probable correct way is to generate `release candidate` tags always before run `release tag` with `hatch` based on `hatch version minor,rc` or `hatch version major,rc`)

An current issue is the necessity to have a double version management (using `hatch` AND `git`'s tags)