### PR TITLE
Add explict install of ghostscript.

### DIFF
--- a/.github/workflows/ci-mac-os.yml
+++ b/.github/workflows/ci-mac-os.yml
@@ -40,7 +40,8 @@ jobs:
           python -m pip install --upgrade pip
 
           # Install requirements for lateXML 
-          brew update   
+          brew update
+          brew install ghostscript
           brew install imagemagick
           brew install --cask basictex
           brew install latexml

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To install `amc2moodle` as a python package on linux or macOS platform, follow t
   -  install python (version >=3.5)
   -  install `imageMagick`, useful to convert image files (*.eps, *.pdf, ...) into png
       - Ubuntu: `sudo apt-get install imagemagick`
-      - MacOS: `brew install imagemagick` (see [`ImageMagick` website](https://imagemagick.org/script/download.php) for more details )
+      - MacOS: `brew install ghostscript imagemagick` (see [`ImageMagick` website](https://imagemagick.org/script/download.php) for more details)
   -  install [`LaTeXML`](http://dlmf.nist.gov/LaTeXML) [tested with version >= 0.8.1] This program does the first step of the conversion into XML
       - Ubuntu: `sudo apt-get install latexml`
       - see also [LaTeXML wiki](https://github.com/brucemiller/LaTeXML/wiki/Installation-Guides) or [install notes](https://dlmf.nist.gov/LaTeXML/get.html) that all the dependencies are installed (perl, latex, imagemagick).


### PR DESCRIPTION
Homebrew recipe drops `ghostscript` dependency. We now need to add it explicitly in the CI script. 

see:
https://github.com/Homebrew/homebrew-core/pull/220197